### PR TITLE
Update models.py

### DIFF
--- a/django_nyt/models.py
+++ b/django_nyt/models.py
@@ -130,7 +130,7 @@ class Notification(models.Model):
     )
     # Or the user to receive the notification
     user = models.ForeignKey(
-        'auth.User',
+        settings.USER_MODEL,
         null=True,
         blank=True,
         on_delete=models.CASCADE,  # If a user is deleted, remove all notifications


### PR DESCRIPTION
When using a custom user model application fails due to wrong database relation.
This fix ensures that the proper user model is used.
