### PR TITLE
Fix filter_exclude

### DIFF
--- a/django_nyt/models.py
+++ b/django_nyt/models.py
@@ -180,7 +180,8 @@ class Notification(models.Model):
 
         objects_created = []
         subscriptions = Subscription.objects.filter(
-            notification_type__key=key,
+            notification_type__key=key
+        ).exclude(
             **filter_exclude
         )
         if object_id:


### PR DESCRIPTION
filter_exclude was actually doing the opposite of the intention.
.filter() is used for matching while .exclude() is used to not match.

You should probably consider renaming filter_exclude to just exclude. I didn't do it since django-wiki also uses filter_exclude. 

This fixes the odd behavior in django-wiki where it only notifies the user that edited the article instead of everyone else who is subscribed. 
