### PR TITLE
Fix setup.py sdist related issues and use only __version__

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -1,6 +1,0 @@
-include LICENSE
-include README.md
-include README.rst
-include setup.cfg
-include requirements.txt
-recursive-include django_nyt *.html *.txt *.png *.js *.css *.gif *.less *.mo *.po *.otf *.svg *.woff *.eot *.ttf

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,4 @@ include LICENSE
 include README.rst
 include setup.cfg
 include requirements.txt
-# None of these exist
-# recursive-include django_nyt *.html *.txt *.png *.js *.css *.gif *.less *.mo *.po *.otf *.svg *.woff *.eot *.ttf
+recursive-include django_nyt *.html *.js *.mo *.po

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ release: clean sdist
 	twine upload -s dist/*
 
 sdist: clean
+	cd django_nyt && django-admin compilemessages
 	python setup.py sdist
 	python setup.py bdist_wheel
 	ls -l dist

--- a/django_nyt/__init__.py
+++ b/django_nyt/__init__.py
@@ -1,7 +1,6 @@
 _disable_notifications = False
 
-VERSION = "1.1b1"
-__version__ = VERSION
+__version__ = "1.1b1"
 
 default_app_config = "django_nyt.apps.DjangoNytConfig"
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -12,7 +12,7 @@ New features
 Bug fixes
 ^^^^^^^^^
 
- * ...
+ * Restored missing translation files :url-issue:`73`
 
 Deprecations
 ^^^^^^^^^^^^
@@ -20,6 +20,7 @@ Deprecations
  * Django < 1.11 support is dropped :url-issue:`62`
  * Python < 3.4 support is dropped :url-issue:`65` and :url-issue:`68`
  * Deprecate ``django_nyt.urls.get_pattern``, use ``include('django_nyt.urls')`` instead :url-issue:`63`
+ * Removed ``django_nyt.VERSION``, use `django_nyt.__version__` instead :url-issue:`73`
 
 1.0
 ---

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
 import os
-from django_nyt import VERSION
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
+
+from django_nyt import __version__
+
 
 def get_path(fname):
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), fname)
@@ -8,18 +11,19 @@ def get_path(fname):
 def read(fname):
     return open(get_path(fname)).read()
 
+
 packages = find_packages()
 
 setup(
     name="django-nyt",
-    version=VERSION,
+    version=__version__,
     author="Benjamin Bach",
     author_email="benjamin@overtag.dk",
     url="https://github.com/benjaoming/django-nyt",
     description="A pluggable notification system written for the Django framework.",
     license="Apache License 2.0",
     keywords=["django", "notification" "alerts"],
-    packages=find_packages(exclude=["testproject", "testproject.*"]),
+    packages=find_packages(),
     zip_safe=False,
     install_requires=read('requirements.txt').split("\n"),
     classifiers=[


### PR DESCRIPTION
Seems there were two times `MANIFEST` and `MANIFEST.in`

CC: @rsalmaso 