### PR TITLE
Use context manager for open file

### DIFF
--- a/django_nyt/management/commands/notifymail.py
+++ b/django_nyt/management/commands/notifymail.py
@@ -91,9 +91,8 @@ class Command(BaseCommand):
             if fpid > 0:
                 # Running as daemon now. PID is fpid
                 self.logger.info("PID: %s" % str(fpid))
-                pid_file = open(self.options['pid'], "w")
-                pid_file.write(str(fpid))
-                pid_file.close()
+                with open(self.options['pid'], "w") as pid_file:
+                    pid_file.write(str(fpid))
                 if not self.options['no_sys_exit']:
                     sys.exit(0)
         except OSError as e:


### PR DESCRIPTION
Context managers is modern - I suppose the code was written before this support was added in Python, but we now support Python 3, so we're safe.
Context managers is safe - all resources are always released.
Context managers is clear - the intention is simpler to grasp, the code is more "pythonic"