### PR TITLE
Add support for Django 4.1

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -57,6 +57,7 @@ settings.configure(
         'django.contrib.auth.middleware.AuthenticationMiddleware',
         'django.contrib.messages.middleware.MessageMiddleware',
     ],
+    DEFAULT_AUTO_FIELD='django.db.models.AutoField',
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,29 @@
-from setuptools import find_packages
-from setuptools import setup
+from pathlib import Path
+from setuptools import find_packages, setup
 
 from django_nyt import __version__
 
 
-packages = find_packages()
+this_directory = Path(__file__).parent
+long_description = (this_directory / 'README.rst').read_text()
+
 
 setup(
-    name="django-nyt",
+    name='django-nyt',
     version=__version__,
-    author="Benjamin Bach",
-    author_email="benjamin@overtag.dk",
-    url="https://github.com/benjaoming/django-nyt",
-    description="A pluggable notification system written for the Django framework.",
-    license="Apache License 2.0",
-    keywords=["django", "notification" "alerts"],
+    author='Benjamin Bach',
+    description='A pluggable notification system written for the Django framework.',
+    long_description=long_description,
+    long_description_content_type='text/x-rst',
+    author_email='benjamin@overtag.dk',
+    url='https://github.com/benjaoming/django-nyt',
+    license='Apache License 2.0',
+    keywords=['django', 'notification', 'alerts'],
     packages=find_packages(),
+    include_package_data=True,
     zip_safe=False,
-    install_requires=["django>=2.2,<4.1"],
+    install_requires=['django>=2.2,<4.2'],
+    python_requires='>=3.5',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
@@ -38,5 +44,11 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3 :: Only',
     ],
-    include_package_data=True,
+    project_urls={
+        'Funding': 'https://donate.pypi.org',
+        'Documentation': 'https://django-nyt.readthedocs.io/en/latest/',
+        'Release notes': 'https://github.com/django-wiki/django-nyt/releases',
+        'Source': 'https://github.com/django-wiki/django-nyt',
+        'Tracker': 'https://github.com/django-wiki/django-nyt/issues',
+    },
 )

--- a/test-project/testproject/settings/__init__.py
+++ b/test-project/testproject/settings/__init__.py
@@ -37,8 +37,7 @@ MEDIA_URL = '/media/'
 
 STATIC_ROOT = os_path.join(PROJECT_PATH, 'static')
 STATIC_URL = '/static/'
-STATICFILES_DIRS = (
-)
+STATICFILES_DIRS = ()
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
@@ -154,3 +153,4 @@ if _enable_channels:
 
 
 NYT_ENABLE_ADMIN = True
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # Ensure you add to .circleci/config.yml if you add here
-envlist = {py35,py36,py37,py38,py39,pypy}-django{22,30,31,32},{py36,py37,py38,py39,py310}-django{32},{py38,py39,py310}-django{40},
+envlist = {py35,py36,py37,py38,py39,pypy}-django{22,30,31,32},{py36,py37,py38,py39,py310}-django{32},{py38,py39,py310}-django{40},{py38,py39,py310}-django{41},
 
 [testenv]
 passenv = CODECOV_TOKEN
@@ -22,6 +22,7 @@ deps =
   django31: Django>=3.1,<3.2
   django32: Django>=3.2,<3.3
   django40: Django>=4.0,<4.1
+  django41: Django>=4.1,<4.2
 
 basepython =
   py35: python3.5


### PR DESCRIPTION
This pull request fixes the issue #112 and as well include minor fixes to the setup file.

```
❯ twine check dist/*
Checking dist/django_nyt-1.2.3-py3-none-any.whl: PASSED
Checking dist/django-nyt-1.2.3.tar.gz: PASSED
```