### PR TITLE
Adds arguments to set domain and http protocol from CLI

### DIFF
--- a/django_nyt/management/commands/notifymail.py
+++ b/django_nyt/management/commands/notifymail.py
@@ -51,6 +51,20 @@ class Command(BaseCommand):
             default="/tmp/nyt_daemon.pid",
         )
         parser.add_argument(
+            "--domain",
+            action="store",
+            dest="domain",
+            help="Base domain to use for URLs (excluding HTTP protocol).",
+            default="",
+        )
+        parser.add_argument(
+            "--http-only",
+            action="store_true",
+            dest="http",
+            help="Use http:// in URLs instead of https://.",
+            default=False,
+        )
+        parser.add_argument(
             "--log-file",
             action="store",
             dest="log",
@@ -267,7 +281,11 @@ class Command(BaseCommand):
                 "username": None,
                 "notifications": None,
                 "digest": None,
-                "site": Site.objects.get_current(),
+                "site": Site.objects.get_current()
+                if not self.options["domain"]
+                else None,
+                "domain": self.options["domain"] or Site.objects.get_current().domain,
+                "http_scheme": "http" if self.options["http"] else "https",
             }
 
             context["user"] = setting.user

--- a/django_nyt/templates/notifications/emails/default.txt
+++ b/django_nyt/templates/notifications/emails/default.txt
@@ -1,13 +1,13 @@
 {% load i18n %}{% autoescape off %}{% blocktrans with username as username %}Dear {{ username }},{% endblocktrans %}
 
-{% blocktrans with site.name as site %}These are notifications sent {{ digest }} from {{ site }}.{% endblocktrans %}
+{% blocktrans with site.name|default:domain as site %}These are notifications sent {{ digest }} from {{ site }}.{% endblocktrans %}
 {% for n in notifications %}
  * {{ n.message }}{% if n.url %}
-   https://{{ site.domain }}{{n.url}}{% endif %}
+   {% if "://" in n.url %}{{ n.url }}{% else %}{{ http_scheme }}://{{ domain }}{{ n.url }}{% endif %}{% endif %}
 {% endfor %}
 
 {% trans "Thanks for using our site!" %}
 
 {% trans "Sincerely" %},
-{{ site.name }}
+{{ site.name|default:domain }}
 {% endautoescape %}

--- a/django_nyt/templates/notifications/emails/default_subject.txt
+++ b/django_nyt/templates/notifications/emails/default_subject.txt
@@ -1,2 +1,2 @@
 {% load i18n %}
-{% blocktrans with site.name as site %} You have new notifications from {{ site }} (type: {{ digest }}){% endblocktrans %}
+{% blocktrans %} You have new notifications from {{ domain }} (type: {{ digest }}){% endblocktrans %}

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -13,6 +13,7 @@ Release Notes
   so it's now encouraged to use ``/`` separators in notification keys,
   for instance ``comments/new`` is matched by ``comments/**``. #125 (Benjamin Balder Bach)
 * Django 5 support #128 (Benjamin Balder Bach)
+* New arguments ``--domain`` and ``--http-only`` for management command ``notifymail`` #130 (Benjamin Balder Bach)
 
 **Changed**
 

--- a/tests/core/test_email.py
+++ b/tests/core/test_email.py
@@ -105,6 +105,38 @@ example.com
 """
         )
 
+    def test_notify_with_url_domain(self):
+        mail.outbox = []
+
+        # Subscribe User 1 to test key
+        utils.subscribe(self.user1_settings, self.TEST_KEY, send_emails=True)
+        utils.notify("Test is a test", self.TEST_KEY, url="/test")
+
+        call_command("notifymail", "--cron", "--no-sys-exit", "--domain=foobar.com")
+
+        assert len(mail.outbox) == 1
+        assert (
+            mail.outbox[0].subject
+            == "You have new notifications from foobar.com (type: instantly)"
+        )
+        assert (
+            mail.outbox[0].body
+            == """Dear alice,
+
+These are notifications sent instantly from foobar.com.
+
+ * Test is a test
+   https://foobar.com/test
+
+
+Thanks for using our site!
+
+Sincerely,
+foobar.com
+
+"""
+        )
+
     @override_settings(
         NYT_EMAIL_TEMPLATE_NAMES=OrderedDict(
             {NotifyTestBase.TEST_KEY: "testapp/notifications/email.txt"}


### PR DESCRIPTION
Have an option to avoid using `Site.objects.get_current`, although we should also check if it's even in INSTALLED_APPS.