### PR TITLE
Add Django 5.2 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,9 @@ workflows:
           hatch_env: "py3.10-dj5.1"
           python_version: "3.10"
       - hatch:
+          hatch_env: "py3.10-dj5.2"
+          python_version: "3.10"
+      - hatch:
           hatch_env: "py3.11-dj4.1"
           python_version: "3.11"
       - hatch:
@@ -106,9 +109,21 @@ workflows:
           hatch_env: "py3.11-dj5.1"
           python_version: "3.11"
       - hatch:
-          hatch_env: "py3.11-dj5.0"
+          hatch_env: "py3.12-dj5.0"
           python_version: "3.12"
       - hatch:
-          hatch_env: "py3.11-dj5.1"
+          hatch_env: "py3.12-dj5.1"
           python_version: "3.12"
+      - hatch:
+          hatch_env: "py3.12-dj5.2"
+          python_version: "3.12"
+      - hatch:
+          hatch_env: "py3.13-dj5.0"
+          python_version: "3.13"
+      - hatch:
+          hatch_env: "py3.13-dj5.1"
+          python_version: "3.13"
+      - hatch:
+          hatch_env: "py3.13-dj5.2"
+          python_version: "3.13"
       - lint

--- a/django_nyt/__init__.py
+++ b/django_nyt/__init__.py
@@ -1,5 +1,5 @@
 _disable_notifications = False
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"
 
 default_app_config = "django_nyt.apps.DjangoNytConfig"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 dependencies = [
-    "django>=2.2,<5.2",
+    "django>=2.2,<5.3",
 ]
 dynamic = ["version"]
 
@@ -124,8 +124,8 @@ python = ["3.8", "3.9", "3.10", "3.11"]
 django = ["4.1", "4.2"]
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.10", "3.11", "3.12"]
-django = ["5.0", "5.1"]
+python = ["3.10", "3.11", "3.12", "3.13"]
+django = ["5.0", "5.1", "5.2"]
 
 [tool.hatch.envs.test.scripts]
 all = [


### PR DESCRIPTION
Hi,

Since Django 5.2 is an LTS release, it would be cool if django-wiki would support it, so I added the necessary changes to django-nyt in preparation for another PR to django-wiki

Also I added declarations for Python 3.13 support as this matches what [Django 5.2 recommends](https://docs.djangoproject.com/en/5.2/releases/5.2/#:~:text=Django%205.2%20supports%20Python%203.10,latest%20release%20of%20each%20series.)