### PR TITLE
add --retries to notifymail to avoid infinite retries

### DIFF
--- a/django_nyt/management/commands/notifymail.py
+++ b/django_nyt/management/commands/notifymail.py
@@ -91,6 +91,18 @@ class Command(BaseCommand):
             dest="now",
             help="Simulate when to start sending from (mainly for testing purposes)",
         )
+        parser.add_argument(
+            "--retries",
+            help="How many time to retry if encountering errors when sending the emails",
+            default=3,
+            type=int,
+        )
+        parser.add_argument(
+            "--retries_cooldown",
+            help="Time in seconds to wait before trying again to send the emails",
+            default=30,
+            type=int,
+        )
 
     def _render_and_send(
         self, template_name, template_subject_name, context, connection
@@ -238,7 +250,7 @@ class Command(BaseCommand):
         if len(context["notifications"]) == 0:
             return
 
-        while True:
+        for retry in range(self.options["retries"]):
             notification_ids = [n.id for n in notifications]
             try:
                 self.logger.info(f"Sending to notification ids {notification_ids}")
@@ -256,11 +268,10 @@ class Command(BaseCommand):
                 break
             except smtplib.SMTPSenderRefused:
                 self.logger.error(
-                    ("E-mail refused by SMTP server ({}), " "skipping!").format(
+                    ("E-mail refused by SMTP server ({}), skipping!").format(
                         setting.user.email
                     )
                 )
-                continue
             except smtplib.SMTPException as e:
                 self.logger.error(
                     (
@@ -268,13 +279,19 @@ class Command(BaseCommand):
                         "connection, error is: {}"
                     ).format(e)
                 )
-                self.logger.error("Sleeping for 30s then retrying...")
-                time.sleep(30)
             except Exception as e:
                 self.logger.error(
-                    ("Unhandled exception while sending, giving " "up: {}").format(e)
+                    ("Unhandled exception while sending, giving up: {}").format(e)
                 )
                 raise
+            self.logger.error(
+                f"Sleeping for 30s then retrying ({retry + 1} of {self.options['retries']})..."
+            )
+            time.sleep(self.options["retries_cooldown"])
+        else:
+            raise RuntimeError(
+                f"Failed to send notifications after {self.options['retries']} tentatives."
+            )
 
     def send_mails(  # noqa: max-complexity=12
         self, connection, now, last_sent=None, user_settings=None

--- a/django_nyt/management/commands/notifymail.py
+++ b/django_nyt/management/commands/notifymail.py
@@ -98,9 +98,10 @@ class Command(BaseCommand):
             type=int,
         )
         parser.add_argument(
-            "--retries_cooldown",
+            "--retries-cooldown",
             help="Time in seconds to wait before trying again to send the emails",
             default=30,
+            dest="retries_cooldown",
             type=int,
         )
 


### PR DESCRIPTION
Hey !

Just stumbled on a case where I had the wrong "from" email address, which gets rejected by the server with `Different sender identity is not allowed.`. In this case, it seems the `notifymail` command just retries forever.

Retrying a few times could make sense for potentially transient errors, but and inifinite loop certains is more harmful than helpful (esp. for `cron` commands).

So this PR adds `--retries` and `--retries_cooldown` arguments to `notifymail`, defaulting to 3 and 30s.

Warning: this is not backwards compatible for anyone coulting on infinite retries (but that sounds quite wrong no ?).

Also I didn't write tests, as I didn't see tests dealing with retries, and didn't write docs since I think with the command's help this is already discoverable.

Let me know if this is fine with you.

Cheers
