### PR TITLE
Filter notifymail to only send to active users

### DIFF
--- a/django_nyt/management/commands/notifymail.py
+++ b/django_nyt/management/commands/notifymail.py
@@ -207,6 +207,7 @@ class Command(BaseCommand):
             # an interval greater than our last_sent marker.
             if last_sent:
                 user_settings = models.Settings.objects.filter(
+                    user__is_active=True,
                     interval__lte=((started_sending_at - last_sent).seconds // 60) // 60
                 ).order_by("user")
                 now = self.options.get("now") or timezone.now()
@@ -291,7 +292,7 @@ class Command(BaseCommand):
 
         if not user_settings:
             user_settings = (
-                models.Settings.objects.all()
+                models.Settings.objects.filter(user__is_active=True)
                 .select_related("user")
                 .prefetch_related(
                     "subscription_set", "subscription_set__notification_type"

--- a/django_nyt/management/commands/notifymail.py
+++ b/django_nyt/management/commands/notifymail.py
@@ -208,7 +208,8 @@ class Command(BaseCommand):
             if last_sent:
                 user_settings = models.Settings.objects.filter(
                     user__is_active=True,
-                    interval__lte=((started_sending_at - last_sent).seconds // 60) // 60
+                    interval__lte=((started_sending_at - last_sent).seconds // 60)
+                    // 60,
                 ).order_by("user")
                 now = self.options.get("now") or timezone.now()
             else:


### PR DESCRIPTION
This limits sending e-mail notifications to only active users. Non-active users shouldn't be receiving notifications.

There's a chance this could be configurable as it could be a breaking change, but wanted to put it out there like this first.