### PR TITLE
Add HTML email template support to notifymail with text fallback

### DIFF
--- a/django_nyt/management/commands/notifymail.py
+++ b/django_nyt/management/commands/notifymail.py
@@ -106,32 +106,41 @@ class Command(BaseCommand):
         subject = subject.replace("\n", "").strip()
 
         bodies = {}
-        for ext in ['html', 'txt']:
+        for ext in ["html", "txt"]:
             try:
                 # Adjust default naming of templates to drop the default ext
-                available_template_name = '%s.%s' % (template_name.rsplit(".", 1)[0], ext)
+                available_template_name = "%s.%s" % (
+                    template_name.rsplit(".", 1)[0],
+                    ext,
+                )
                 bodies[ext] = render_to_string(available_template_name, context).strip()
             except TemplateDoesNotExist:
                 # Need at least html or text message body
-                if ext == 'txt' and not bodies:
+                if ext == "txt" and not bodies:
                     raise
 
-        if 'txt' in bodies:
+        if "txt" in bodies:
             email = mail.EmailMultiAlternatives(
-                subject, bodies['txt'], app_settings.NYT_EMAIL_SENDER,
-                [context['user'].email], connection=connection
+                subject,
+                bodies["txt"],
+                app_settings.NYT_EMAIL_SENDER,
+                [context["user"].email],
+                connection=connection,
             )
 
-            if 'html' in bodies:
-                email.attach_alternative(bodies['html'], 'text/html')
+            if "html" in bodies:
+                email.attach_alternative(bodies["html"], "text/html")
         else:
             email = mail.EmailMessage(
-                subject, bodies['html'], app_settings.NYT_EMAIL_SENDER,
-                [context['user'].email], connection=connection
+                subject,
+                bodies["html"],
+                app_settings.NYT_EMAIL_SENDER,
+                [context["user"].email],
+                connection=connection,
             )
-            email.content_subtype = 'html'  # Set main content text/html
+            email.content_subtype = "html"  # Set main content text/html
 
-        self.logger.info("Sending to: %s" % context['user'].email)
+        self.logger.info("Sending to: %s" % context["user"].email)
         email.send(fail_silently=False)
 
     def _daemonize(self):

--- a/django_nyt/management/commands/notifymail.py
+++ b/django_nyt/management/commands/notifymail.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.core import mail
 from django.core.management.base import BaseCommand
 from django.db.models import Q
+from django.template import TemplateDoesNotExist
 from django.template.loader import render_to_string
 from django.utils import timezone
 from django.utils.translation import activate
@@ -95,7 +96,6 @@ class Command(BaseCommand):
     def _render_and_send(
         self, template_name, template_subject_name, context, connection
     ):
-
         # This setting overrides everything
         if app_settings.NYT_EMAIL_SUBJECT:
             # Notice that this usually is a lazy translation object
@@ -105,15 +105,33 @@ class Command(BaseCommand):
 
         subject = subject.replace("\n", "").strip()
 
-        message = render_to_string(template_name, context)
-        email = mail.EmailMessage(
-            subject,
-            message,
-            app_settings.NYT_EMAIL_SENDER,
-            [context["user"].email],
-            connection=connection,
-        )
-        self.logger.info("Sending to: %s" % context["user"].email)
+        bodies = {}
+        for ext in ['html', 'txt']:
+            try:
+                # Adjust default naming of templates to drop the default ext
+                available_template_name = '%s.%s' % (template_name.rsplit(".", 1)[0], ext)
+                bodies[ext] = render_to_string(available_template_name, context).strip()
+            except TemplateDoesNotExist:
+                # Need at least html or text message body
+                if ext == 'txt' and not bodies:
+                    raise
+
+        if 'txt' in bodies:
+            email = mail.EmailMultiAlternatives(
+                subject, bodies['txt'], app_settings.NYT_EMAIL_SENDER,
+                [context['user'].email], connection=connection
+            )
+
+            if 'html' in bodies:
+                email.attach_alternative(bodies['html'], 'text/html')
+        else:
+            email = mail.EmailMessage(
+                subject, bodies['html'], app_settings.NYT_EMAIL_SENDER,
+                [context['user'].email], connection=connection
+            )
+            email.content_subtype = 'html'  # Set main content text/html
+
+        self.logger.info("Sending to: %s" % context['user'].email)
         email.send(fail_silently=False)
 
     def _daemonize(self):

--- a/django_nyt/templates/notifications/emails/default.html
+++ b/django_nyt/templates/notifications/emails/default.html
@@ -1,0 +1,14 @@
+{% load i18n %}<html><body>{% autoescape off %}{% blocktrans with username as username %}Dear {{ username }},{% endblocktrans %}
+
+{% blocktrans with site.name as site %}These are the {{ digest }} notifications from {{ site }}.{% endblocktrans %}
+<ul>
+{% for n in notifications %}
+ <li> {{ n.message }}<br>
+   <a href=">http://{{ site.domain }}{{n.url}}">http://{{ site.domain }}{{n.url}}</a></li>
+{% endfor %}
+</ul>
+{% trans "Thanks for using our site!" %}
+
+{% trans "Sincerely" %},
+{{ site.name }}
+{% endautoescape %}</body></html>


### PR DESCRIPTION
Pretty straight forward, adds support for email templates the same name as the text ones.