### PR TITLE
Feature/notification interval never

### DIFF
--- a/django_nyt/conf.py
+++ b/django_nyt/conf.py
@@ -22,6 +22,7 @@ from django.utils.translation import gettext_lazy as _
 # through django.conf.settings.
 settings_prefix = "NYT_"
 
+NEVER = -1
 INSTANTLY = 0
 # Subtract 1, because the job finishes less than 24h before the next...
 DAILY = (24 - 1) * 60
@@ -102,11 +103,12 @@ class AppSettings:
     """
 
     NYT_INTERVALS: list[tuple[int, Any]] | tuple[tuple[int, Any]] = (
+        (NEVER, _("never")),
         (INSTANTLY, _("instantly")),
         (DAILY, _("daily")),
         (WEEKLY, _("weekly")),
     )
-    """List of intervals available for user selections. In minutes"""
+    """List of intervals available for user selections. In minutes. -1 disables email notifications."""
 
     NYT_INTERVALS_DEFAULT: int = INSTANTLY
     """Default selection for new subscriptions"""

--- a/django_nyt/management/commands/notifymail.py
+++ b/django_nyt/management/commands/notifymail.py
@@ -242,9 +242,12 @@ class Command(BaseCommand):
             notification_ids = [n.id for n in notifications]
             try:
                 self.logger.info(f"Sending to notification ids {notification_ids}")
-                self._render_and_send(
-                    template_name, subject_template_name, context, connection
-                )
+                # Allow users to disable e-mail notifications from sending (but
+                # mark them as sent so they won't be sent in the future)
+                if setting.interval > -1:
+                    self._render_and_send(
+                        template_name, subject_template_name, context, connection
+                    )
                 for n in notifications:
                     n.is_emailed = True
                     n.save()

--- a/django_nyt/migrations/0011_add_interval_to_disable_email_notifications.py
+++ b/django_nyt/migrations/0011_add_interval_to_disable_email_notifications.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('django_nyt', '0010_settings_created_settings_modified_and_more'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='settings',
+            name='interval',
+            field=models.SmallIntegerField(default=0, verbose_name='interval', choices=[(-1, 'never'), (0, 'instantly'), (1380, 'daily'), (9660, 'weekly')]),
+        ),
+    ]

--- a/django_nyt/migrations/0011_add_interval_to_disable_email_notifications.py
+++ b/django_nyt/migrations/0011_add_interval_to_disable_email_notifications.py
@@ -11,6 +11,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='settings',
             name='interval',
-            field=models.SmallIntegerField(default=0, verbose_name='interval', choices=[(-1, 'never'), (0, 'instantly'), (1380, 'daily'), (9660, 'weekly')]),
+            field=models.SmallIntegerField(choices=[(-1, 'never'), (0, 'instantly'), (1380, 'daily'), (9660, 'weekly')], default=0, help_text='interval in minutes (0=instant, 60=notify once per hour)', verbose_name='interval'),
         ),
     ]

--- a/django_nyt/migrations/0011_add_interval_to_disable_email_notifications.py
+++ b/django_nyt/migrations/0011_add_interval_to_disable_email_notifications.py
@@ -1,16 +1,27 @@
-from django.db import migrations, models
+from django.db import migrations
+from django.db import models
 
 
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('django_nyt', '0010_settings_created_settings_modified_and_more'),
+        ("django_nyt", "0010_settings_created_settings_modified_and_more"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='settings',
-            name='interval',
-            field=models.SmallIntegerField(choices=[(-1, 'never'), (0, 'instantly'), (1380, 'daily'), (9660, 'weekly')], default=0, help_text='interval in minutes (0=instant, 60=notify once per hour)', verbose_name='interval'),
+            model_name="settings",
+            name="interval",
+            field=models.SmallIntegerField(
+                choices=[
+                    (-1, "never"),
+                    (0, "instantly"),
+                    (1380, "daily"),
+                    (9660, "weekly"),
+                ],
+                default=0,
+                help_text="interval in minutes (0=instant, 60=notify once per hour)",
+                verbose_name="interval",
+            ),
         ),
     ]


### PR DESCRIPTION
This adds an interval of -1, meaning never send any notifications. It also configures `notifymail` to skip sending to anyone with `interval=-1` (well < 0).

There are multiple ways to do this, we've been using this in production for quite some time so just wanted to split it up and send it over.