### PR TITLE
Add NYT_SEND_ONLY_LATEST setting to send only latest notification per subscription

### DIFF
--- a/django_nyt/conf.py
+++ b/django_nyt/conf.py
@@ -52,6 +52,11 @@ class AppSettings:
     consider a no-reply kind of email if your notification system has a UI for changing
     notification settings."""
 
+    NYT_SEND_ONLY_LATEST: bool = True
+    """Email notifications are sent to subscribers, by default only the latest
+    notification for each subscription is sent. When false, sends all of the
+    unsent notifications to subscribers."""
+
     NYT_EMAIL_TEMPLATE_DEFAULT: str = "notifications/emails/default.txt"
     """Default template used for rendering email contents.
     Should contain a valid template name.

--- a/django_nyt/conf.py
+++ b/django_nyt/conf.py
@@ -53,7 +53,7 @@ class AppSettings:
     consider a no-reply kind of email if your notification system has a UI for changing
     notification settings."""
 
-    NYT_SEND_ONLY_LATEST: bool = True
+    NYT_SEND_ONLY_LATEST: bool = False
     """Email notifications are sent to subscribers, by default only the latest
     notification for each subscription is sent. When false, sends all of the
     unsent notifications to subscribers."""

--- a/django_nyt/management/commands/notifymail.py
+++ b/django_nyt/management/commands/notifymail.py
@@ -377,9 +377,14 @@ class Command(BaseCommand):
                 # Always, no matter what.
                 # This also means that if we are sending out emails every 5 minutes, and several
                 # notifications have been triggered meanwhile, they'll go into the same email.
-                emails_per_template[(template_name, subject_template_name)] += list(
-                    subscription.notification_set.filter(is_emailed=False),
-                )
+                if app_settings.NYT_SEND_ONLY_LATEST:
+                    emails_per_template[(template_name, subject_template_name)] += list(
+                        subscription.latest,
+                    )
+                else:
+                    emails_per_template[(template_name, subject_template_name)] += list(
+                        subscription.notification_set.filter(is_emailed=False),
+                    )
 
             # Send the prepared template names, subjects and context to the user
             for (


### PR DESCRIPTION
This lets the admin configure only sending the latest notification.

For example, if you had a 5 minute interval configured and in that five minute span you received 10 notifications on a subscription, only the most recent would send. This has no impact on users that receive instant notifications. It's just an option to cut down on the volume of notifications being sent.