### PR TITLE
Add target_obj, type_label and target fields to notification JSON data

### DIFF
--- a/django_nyt/models.py
+++ b/django_nyt/models.py
@@ -1,7 +1,8 @@
 import re
 
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Q
 from django.db.models.signals import post_delete

--- a/django_nyt/models.py
+++ b/django_nyt/models.py
@@ -1,7 +1,7 @@
 import re
 
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import models
 from django.db.models import Q
 from django.db.models.signals import post_delete
@@ -306,6 +306,20 @@ class Subscription(models.Model):
         db_table = app_settings.NYT_DB_TABLE_PREFIX + "_subscription"
         verbose_name = _("subscription")
         verbose_name_plural = _("subscriptions")
+
+    @property
+    def target_obj(self):
+        """Returns GFK object for this subscription (if there is one specified)"""
+        if not self.object_id or not self.notification_type.content_type:
+            return None
+
+        obj_type = self.notification_type.content_type
+        try:
+            obj = obj_type.get_object_for_this_type(pk=self.object_id)
+        except ObjectDoesNotExist:
+            obj = None
+
+        return obj
 
 
 class Notification(models.Model):

--- a/django_nyt/views.py
+++ b/django_nyt/views.py
@@ -32,7 +32,7 @@ def get_notifications(request, latest_id=None, is_viewed=False, max_results=10):
                      "occurrences": n.occurrences,
                      "occurrences_msg": _("%d times") % n.occurrences,
                      "type": n.subscription.notification_type.key if n.subscription else None,
-                     "type_lbl": n.subscription.notification_type.label if n.subscription else None,
+                     "type_label": n.subscription.notification_type.label if n.subscription else None,
                      "since": naturaltime(n.created)} for n in notifications[:max_results]]}
     """
 
@@ -71,7 +71,7 @@ def get_notifications(request, latest_id=None, is_viewed=False, max_results=10):
                 "type": n.subscription.notification_type.key
                 if n.subscription
                 else None,
-                "type_lbl": n.subscription.notification_type.label
+                "type_label": n.subscription.notification_type.label
                 if n.subscription
                 else None,
                 "since": naturaltime(n.created),

--- a/django_nyt/views.py
+++ b/django_nyt/views.py
@@ -28,7 +28,7 @@ def get_notifications(request, latest_id=None, is_viewed=False, max_results=10):
          "objects": [{"pk": n.pk,
                      "message": n.message,
                      "url": n.url,
-                     "target": str(n.subscription.target_obj) if n.subscription and n.subscription.object_id else None,
+                     "target": str(n.subscription.target_obj) if n.subscription else None,
                      "occurrences": n.occurrences,
                      "occurrences_msg": _("%d times") % n.occurrences,
                      "type": n.subscription.notification_type.key if n.subscription else None,

--- a/django_nyt/views.py
+++ b/django_nyt/views.py
@@ -62,14 +62,18 @@ def get_notifications(request, latest_id=None, is_viewed=False, max_results=10):
             {
                 "pk": n.pk,
                 "message": n.message,
-                "target": str(n.subscription.target_obj) if n.subscription and n.subscription.object_id else None,
+                "target": str(n.subscription.target_obj)
+                if n.subscription and n.subscription.object_id
+                else None,
                 "url": n.url,
                 "occurrences": n.occurrences,
                 "occurrences_msg": _("%d times") % n.occurrences,
                 "type": n.subscription.notification_type.key
                 if n.subscription
                 else None,
-                "type_lbl": n.subscription.notification_type.label if n.subscription else None,
+                "type_lbl": n.subscription.notification_type.label
+                if n.subscription
+                else None,
                 "since": naturaltime(n.created),
             }
             for n in notifications[:max_results]

--- a/django_nyt/views.py
+++ b/django_nyt/views.py
@@ -23,15 +23,17 @@ def get_notifications(request, latest_id=None, is_viewed=False, max_results=10):
 
     :returns: An HTTPResponse object with JSON data::
 
-        {'success': True,
-         'total_count': total_count,
-         'objects': [{'pk': n.pk,
-                     'message': n.message,
-                     'url': n.url,
-                     'occurrences': n.occurrences,
-                     'occurrences_msg': _('%d times') % n.occurrences,
-                     'type': n.subscription.notification_type.key if n.subscription else None,
-                     'since': naturaltime(n.created)} for n in notifications[:max_results]]}
+        {"success": True,
+         "total_count": total_count,
+         "objects": [{"pk": n.pk,
+                     "message": n.message,
+                     "url": n.url,
+                     "target": str(n.subscription.target_obj) if n.subscription and n.subscription.object_id else None,
+                     "occurrences": n.occurrences,
+                     "occurrences_msg": _("%d times") % n.occurrences,
+                     "type": n.subscription.notification_type.key if n.subscription else None,
+                     "type_lbl": n.subscription.notification_type.label if n.subscription else None,
+                     "since": naturaltime(n.created)} for n in notifications[:max_results]]}
     """
 
     notifications = models.Notification.objects.filter(
@@ -60,12 +62,14 @@ def get_notifications(request, latest_id=None, is_viewed=False, max_results=10):
             {
                 "pk": n.pk,
                 "message": n.message,
+                "target": str(n.subscription.target_obj) if n.subscription and n.subscription.object_id else None,
                 "url": n.url,
                 "occurrences": n.occurrences,
                 "occurrences_msg": _("%d times") % n.occurrences,
                 "type": n.subscription.notification_type.key
                 if n.subscription
                 else None,
+                "type_lbl": n.subscription.notification_type.label if n.subscription else None,
                 "since": naturaltime(n.created),
             }
             for n in notifications[:max_results]

--- a/django_nyt/views.py
+++ b/django_nyt/views.py
@@ -62,9 +62,7 @@ def get_notifications(request, latest_id=None, is_viewed=False, max_results=10):
             {
                 "pk": n.pk,
                 "message": n.message,
-                "target": str(n.subscription.target_obj)
-                if n.subscription and n.subscription.object_id
-                else None,
+                "target": str(n.subscription.target_obj) if n.subscription else None,
                 "url": n.url,
                 "occurrences": n.occurrences,
                 "occurrences_msg": _("%d times") % n.occurrences,


### PR DESCRIPTION
This PR is a bit more opinionated in that it adds additional data to the notification json.

This came about from needing to understand the object that was notified on to customize the display. As well, having the string of the object let us do certain things, ie `<notification text> on <obj str>`.

It doesn't take anything way, and has fairly little impact, but provides much more possible information to the front end.